### PR TITLE
Added option to show an SSL url

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,6 +4,7 @@ TODOMVC_FRONTEND_URL = $(shell aws cloudformation describe-stacks --stack-name x
 TODOMVC_BACKEND_URL = $(shell aws cloudformation describe-stacks --stack-name xilution-todomvc-sam | jq '.Stacks[0].Outputs[0].OutputValue')
 AWS_STAGING_BUCKET = $(shell jq '.[1].ParameterValue' ./aws/cloud-formation/parameters.json)
 AWS_WEBSITE_BUCKET = $(shell jq '.[0].ParameterValue' ./aws/cloud-formation/parameters.json)
+AWS_REGION = $(shell jq '.SecretsRegion' ./aws/cloud-formation/secrets-config.json)
 
 AWS_CLI_HAS_SECRETS_MANAGER = $(shell aws help | grep secretsmanager)
 ifndef AWS_CLI_HAS_SECRETS_MANAGER
@@ -67,3 +68,6 @@ show-backend-url:
 
 show-xilution-api-key:
 	@echo $(XILUTION_API_KEY)
+	
+show-frontend-ssl-url:
+	@echo https://s3.$(AWS_REGION).amazonaws.com/$(AWS_WEBSITE_BUCKET)/index.html


### PR DESCRIPTION
#49 
Added `make show-frontend-ssl-url`
The quickest/easiest way I was able to find for using SSL for browser authentication is to just use the direct link given for the index file in the S3 bucket console. Bucket permissions already seem to allow for direct linking like this.

Although I think it seems a little dirty to me, I suppose its cleaner than sending password credentials without encryption and is adequate for the purpose of this demonstration. The few alternatives I found added much more complication and work to the set-up process.

I wanted to introduce it as an option and then see if it would be desirable to add to the readme.
